### PR TITLE
libft, printf, gnl: fix building of some tests with Xcode 14.1

### DIFF
--- a/testers/libft/Fsoares.py
+++ b/testers/libft/Fsoares.py
@@ -81,7 +81,7 @@ class Fsoares():
 				bonus = " list_utils.c" if has_bonus() else ""
 				sanitize = "-fsanitize=address" if is_mac() else ""
 				command = (
-				    f"gcc -g {sanitize} {strict} -D TIMEOUT={get_timeout()} -Wall -Wextra -Werror my_utils.c {bonus} "
+				    f"gcc -g {sanitize} {strict} -D TIMEOUT={get_timeout()} -Wall -Wextra -Werror -Wno-deprecated-declarations my_utils.c {bonus} "
 				    + f"test_{func}.c utils/malloc_mock.c utils/utils.c -L. -lft -o test_{func}.out -ldl")
 				logger.info(f"executing {command}")
 				res = subprocess.run(command, shell=True, capture_output=True, text=True)

--- a/tests/get_next_line/fsoares/Makefile
+++ b/tests/get_next_line/fsoares/Makefile
@@ -10,6 +10,10 @@ ifdef EXEC_STRICT
 STRICT		= -D STRICT_MEM
 endif
 
+# SDK headers shipping w/Xcode 14.1 (22/11/01)
+# and later deprecate some functions used here
+CFLAGS		+= -Wno-deprecated-declarations
+
 UNAME = $(shell uname -s)
 ifeq ($(UNAME), Linux)
     CFLAGS = -g -Wall -Wextra -Werror

--- a/tests/printf/fsoares/Makefile
+++ b/tests/printf/fsoares/Makefile
@@ -9,6 +9,10 @@ ifdef EXEC_STRICT
 STRICT		= -D STRICT_MEM
 endif
 
+# SDK headers shipping w/Xcode 14.1 (22/11/01)
+# and later deprecate some functions used here
+CFLAGS		+= -Wno-deprecated-declarations
+
 build_m:
 	-@$(MAKE) -C ../__my_srcs fclean 1> /dev/null
 	-@$(MAKE) -s -C ../__my_srcs all 1> /dev/null


### PR DESCRIPTION
Many libc functions used by some tests are now deprecated.

I have only tested (and therefore patched) tests for libft, printf and gnl; others may be affected by the deprecations.

Example errors (without patch):

paco -in --strict
```
╔══════════════════════════════════════════════════════════════════════════════╗
║                Welcome to Francinette, a 42 tester framework!                ║
╚═══════════════════════╦══════════════════════════════╦═══════════════════════╝
                        ║            printf            ║
                        ╚══════════════════════════════╝


⠋ Preparing framework

⠙ Preparing framework

⠹ Preparing framework

⠸ Preparing framework

⠼ Preparing framework
✔ Preparing framework



⠋ Executing: make fclean all (no bonus)

⠙ Executing: make fclean all (no bonus)

⠹ Executing: make fclean all (no bonus)
✔ Executing: make fclean all (no bonus)



⠋ Compiling tests: fsoares (my own tests)

⠙ Compiling tests: fsoares (my own tests)

⠹ Compiling tests: fsoares (my own tests)

⠸ Compiling tests: fsoares (my own tests)
✖ Compiling tests: fsoares (my own tests)

[1mutils/malloc_mock.c:218:13: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                offset += sprintf(signature + offset, "%s\n", allocs[n].strings[i]);
[0;1;32m                          ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m1 error generated.
[1mutils/utils.c:217:2: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
        sprintf(temp + 46, "\"(%i characters)", len);
[0;1;32m        ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mutils/utils.c:231:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                sprintf(my_bf, "<NULL>");
[0;1;32m                ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mutils/utils.c:243:4: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                        sprintf(my_bf + j++, "\\n");
[0;1;32m                        ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mutils/utils.c:245:4: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                        sprintf(my_bf + j++, "\\t");
[0;1;32m                        ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mutils/utils.c:247:4: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                        sprintf(my_bf + j++, "\\f");
[0;1;32m                        ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mutils/utils.c:249:4: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                        sprintf(my_bf + j++, "\\r");
[0;1;32m                        ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mutils/utils.c:251:4: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                        sprintf(my_bf + j++, "\\v");
[0;1;32m                        ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mutils/utils.c:254:4: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                        sprintf(my_bf + j, "\\%03o", (unsigned char)src[i]);
[0;1;32m                        ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mutils/utils.c:298:13: [0m[0;1;31merror: [0m[1m'vsprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
        g_offset = vsprintf(signature, format, args);
[0;1;32m                   ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:207:1: [0m[0;1;30mnote: [0m'vsprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m9 errors generated.
[1mmandatory.c:6:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:6:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:7:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("\x01\x02\a\v\b\f\r\n");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:7:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("\x01\x02\a\v\b\f\r\n");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:11:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("%%");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:11:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("%%");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:12:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg(" %%");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:12:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg(" %%");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:13:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("%%c");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:13:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("%%c");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:14:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("%%%%%%");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:14:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf_noarg("%%%%%%");
[0;1;32m                ^
[0m[1m./pf_utils.h:113:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf_noarg'[0m
        __test_printf(format_str, "", printf(format_str), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:15:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf("%%%c", 'x');
[0;1;32m                ^
[0m[1m./pf_utils.h:110:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf'[0m
        __test_printf(format_str, ", " #__VA_ARGS__, printf(format_str, __VA_ARGS__), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:15:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf("%%%c", 'x');
[0;1;32m                ^
[0m[1m./pf_utils.h:110:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf'[0m
        __test_printf(format_str, ", " #__VA_ARGS__, printf(format_str, __VA_ARGS__), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:22:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf("%c", 'x');
[0;1;32m                ^
[0m[1m./pf_utils.h:110:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf'[0m
        __test_printf(format_str, ", " #__VA_ARGS__, printf(format_str, __VA_ARGS__), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:22:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf("%c", 'x');
[0;1;32m                ^
[0m[1m./pf_utils.h:110:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf'[0m
        __test_printf(format_str, ", " #__VA_ARGS__, printf(format_str, __VA_ARGS__), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:23:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf(" %c", 'x');
[0;1;32m                ^
[0m[1m./pf_utils.h:110:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf'[0m
        __test_printf(format_str, ", " #__VA_ARGS__, printf(format_str, __VA_ARGS__), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:23:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf(" %c", 'x');
[0;1;32m                ^
[0m[1m./pf_utils.h:110:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf'[0m
        __test_printf(format_str, ", " #__VA_ARGS__, printf(format_str, __VA_ARGS__), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:56:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        WRITE_CHECK(fn_call)                                                          \
[0;1;32m        ^
[0m[1m./pf_utils.h:35:14: [0m[0;1;30mnote: [0mexpanded from macro 'WRITE_CHECK'[0m
                w_offset = sprintf(                                                            \
[0;1;32m                           ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[1mmandatory.c:24:3: [0m[0;1;31merror: [0m[1m'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations][0m
                test_printf("%c ", 'x');
[0;1;32m                ^
[0m[1m./pf_utils.h:110:2: [0m[0;1;30mnote: [0mexpanded from macro 'test_printf'[0m
        __test_printf(format_str, ", " #__VA_ARGS__, printf(format_str, __VA_ARGS__), 0);
[0;1;32m        ^
[0m[1m./pf_utils.h:96:3: [0m[0;1;30mnote: [0mexpanded from macro '__test_printf'[0m
                TEST_STRICT(ft_##fn_call);                                             \
[0;1;32m                ^
[0m[1m./pf_utils.h:50:2: [0m[0;1;30mnote: [0mexpanded from macro 'TEST_STRICT'[0m
        BASE_NULL_CHECK(fn_call, result, {                                            \
[0;1;32m        ^
[0m[1m./utils/utils.h:59:12: [0m[0;1;30mnote: [0mexpanded from macro 'BASE_NULL_CHECK'[0m
                offset = sprintf(                                                          \
[0;1;32m                         ^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: [0m[0;1;30mnote: [0m'sprintf' has been explicitly marked deprecated here[0m
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
[0;1;32m^
[0m[1m/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: [0m[0;1;30mnote: [0mexpanded from macro '__deprecated_msg'[0m
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
[0;1;32m                                                      ^
[0m[0;1;31mfatal error: [0m[1mtoo many errors emitted, stopping now [-ferror-limit=][0m
20 errors generated.
make: [build_m] Error 1 (ignored)
Problem compiling the tests

Summary: no bonus

Failed tests: fsoares
```