### PR TITLE
ft_split: test with the string terminator + a non-empty string.

### DIFF
--- a/tests/libft/fsoares/test_split.c
+++ b/tests/libft/fsoares/test_split.c
@@ -89,6 +89,9 @@ int test_split()
 	expected = init_str_array(5, "1", "2a,", "3", "--h", NULL);
 	res = test_single_split(7, "^^^1^^2a,^^^^3^^^^--h^^^^", '^', expected) && res;
 
+	expected = init_str_array(2, "nonempty", NULL);
+	res = test_single_split(8, "nonempty", '\0', expected) && res;
+
 	return res;
 }
 


### PR DESCRIPTION
For whatever reasons, existing tests that checked behavior with the string terminator always tested with the empty string or an equivalent (e.g. "\0whatever").

But splitting a nonempty string by the terminator can expose memory problems which would otherwise be hidden by the input string being zero-length.

Moulinette (at least in Lausanne) appears to do a similar test.

Example failing ft_split: https://gist.github.com/Rodeo314/250d4d6710274cb778c856341f40859b