### PR TITLE
macOS: suppress inconsequential but very intrusive debug messages printed by Apple's libmalloc in "recent" OSes.

### DIFF
--- a/testers/get_next_line/Fsoares.py
+++ b/testers/get_next_line/Fsoares.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 from typing import Set
 
@@ -22,6 +23,9 @@ class Fsoares(BaseExecutor):
 
 	def __init__(self, tests_dir, temp_dir, to_execute, missing) -> None:
 		super().__init__(tests_dir, temp_dir, to_execute, missing)
+		# macOS: suppress inconsequential but intrusive
+		# debug messages printed by Apple's libmalloc
+		os.environ['MallocNanoZone'] = '0'
 
 	def execute(self):
 		bonus_tests = ["open, close, open", "2 file descriptors", "multiple fds", "test limit fds"]

--- a/testers/libft/Fsoares.py
+++ b/testers/libft/Fsoares.py
@@ -36,6 +36,9 @@ class Fsoares():
 		self.missing = missing
 		self.tests_dir = os.path.join(tests_dir, self.folder)
 		self.git_url = None
+		# macOS: suppress inconsequential but intrusive
+		# debug messages printed by Apple's libmalloc
+		os.environ['MallocNanoZone'] = '0'
 
 	def execute(self):
 		self.compile_test()

--- a/testers/minitalk/Fsoares.py
+++ b/testers/minitalk/Fsoares.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import os
 import re
 import shutil
 import string
@@ -41,6 +42,9 @@ class BgThread(threading.Thread):
 		self.command = command
 		self.return_code = None
 		threading.Thread.__init__(self)
+		# macOS: suppress inconsequential but intrusive
+		# debug messages printed by Apple's libmalloc
+		os.environ['MallocNanoZone'] = '0'
 
 	def run(self):
 		p = subprocess.Popen(self.command.split(), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/testers/pipex/Fsoares.py
+++ b/testers/pipex/Fsoares.py
@@ -92,6 +92,9 @@ class Fsoares(BaseExecutor):
 
 	def __init__(self, tests_dir, temp_dir, to_execute, missing) -> None:
 		super().__init__(tests_dir, temp_dir, to_execute, missing)
+		# macOS: suppress inconsequential but intrusive
+		# debug messages printed by Apple's libmalloc
+		os.environ['MallocNanoZone'] = '0'
 
 	def execute(self):
 		Halo(self.get_info_message("Executing tests")).info()

--- a/testers/printf/Fsoares.py
+++ b/testers/printf/Fsoares.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import random
+import os
 import re
 import string
 
@@ -59,6 +60,9 @@ class Fsoares(BaseExecutor):
 		super().__init__(tests_dir, temp_dir, to_execute, missing)
 		if is_strict():
 			get_context().args.timeout = str(int(get_context().args.timeout) * 10);
+		# macOS: suppress inconsequential but intrusive
+		# debug messages printed by Apple's libmalloc
+		os.environ['MallocNanoZone'] = '0'
 
 	def execute(self):
 		text = self.get_info_message("Compiling tests")


### PR DESCRIPTION
See also: https://stackoverflow.com/a/70209891

 e.g. under macOS Monterey:
 
```
✔ Preparing framework
✔ Executing: norminette
✔ Executing: make fclean all bonus
✔ Compiling tests: fsoares (my own)
ℹ Testing:
test_isalpha.out(69327,0x114492600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_isalpha      : OK
test_isdigit.out(69328,0x11521a600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_isdigit      : OK
test_isalnum.out(69329,0x11dd3a600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_isalnum      : OK
test_isascii.out(69330,0x10eaf7600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_isascii      : OK
test_isprint.out(69331,0x10c0b6600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_isprint      : OK
test_strlen.out(69332,0x116830600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strlen       : OK
test_memset.out(69333,0x10b57a600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_memset       : OK
test_bzero.out(69334,0x11498f600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_bzero        : OK
test_memcpy.out(69335,0x114274600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_memcpy       : OK
test_memmove.out(69336,0x1172d9600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_memmove      : OK
test_strlcpy.out(69337,0x110a25600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strlcpy      : OK
test_strlcat.out(69338,0x115a19600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strlcat      : OK
test_toupper.out(69339,0x11399d600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_toupper      : OK
test_tolower.out(69340,0x114a27600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_tolower      : OK
test_strchr.out(69341,0x1138e2600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strchr       : OK
test_strrchr.out(69342,0x10dd85600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strrchr      : OK
test_strncmp.out(69343,0x11c717600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strncmp      : OK
test_memchr.out(69344,0x10732b600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_memchr       : OK
test_memcmp.out(69345,0x117444600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_memcmp       : OK
test_strnstr.out(69346,0x114f6e600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strnstr      : OK
test_atoi.out(69347,0x111a6a600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_atoi         : OK
test_calloc.out(69348,0x1183e5600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_calloc       : OK
test_strdup.out(69349,0x10aaa1600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strdup       : OK
test_substr.out(69350,0x1154f1600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_substr       : OK
test_strjoin.out(69351,0x10906e600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strjoin      : OK
test_strtrim.out(69352,0x10db4a600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strtrim      : OK
test_split.out(69353,0x1108f7600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_split        : OK
test_itoa.out(69354,0x10f76e600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_itoa         : OK
test_strmapi.out(69355,0x116074600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_strmapi      : OK
test_striteri.out(69356,0x115ba4600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_striteri     : OK
test_putchar_fd.out(69357,0x117b39600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_putchar_fd   : OK
test_putstr_fd.out(69358,0x11db79600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_putstr_fd    : OK
test_putendl_fd.out(69359,0x116933600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_putendl_fd   : OK
test_putnbr_fd.out(69360,0x111c0a600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_putnbr_fd    : OK
test_lstnew.out(69361,0x10f080600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstnew       : OK
test_lstadd_front.out(69362,0x11abc7600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstadd_front : OK
test_lstsize.out(69363,0x110465600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstsize      : OK
test_lstlast.out(69364,0x11d87e600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstlast      : OK
test_lstadd_back.out(69365,0x1096c4600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstadd_back  : OK
test_lstdelone.out(69366,0x111206600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstdelone    : OK
test_lstclear.out(69367,0x10c6bd600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstclear     : OK
test_lstiter.out(69368,0x111f37600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstiter      : OK
test_lstmap.out(69369,0x113721600) malloc: nano zone abandoned due to inability to preallocate reserved vm space.
ft_lstmap       : OK
```