### PR TITLE
auto relaunch terminal

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -78,4 +78,5 @@ fi
 # print help
 "$HOME"/francinette/tester.sh --help
 
-echo "Please close this terminal window and open the terminal again for francinette to work"
+# automatically replace current shell with new one.
+exec "$SHELL"


### PR DESCRIPTION
This will allow for the alias `paco` to be available without having to launch a new terminal. 
Tested in bash as well as zsh. 

Brief explanation: `exec "$SHELL"` will replace the current terminal with a new one (in this case, $SHELL). 

See more: man (1) exec. 