### PR TITLE
bin folder fix

### DIFF
--- a/testers/libft/Alelievr.py
+++ b/testers/libft/Alelievr.py
@@ -51,8 +51,12 @@ class Alelievr():
 			f_init.writelines(lines)
 
 		if platform == "linux" or platform == "linux2":
+			linker_line = "\n\nso:\n\tgcc -nostartfiles -shared -o libft.so "
+			if os.path.exists("../bin"):
+				linker_line += "bin/"
+			linker_line += "*.o\n"
 			with open(Path(self.temp_dir, "..", "__my_srcs", "Makefile"), 'a') as mf:
-				mf.writelines("\n\nso:\n\tgcc -nostartfiles -shared -o libft.so *.o\n")
+				mf.writelines(linker_line)
 
 	def execute_tester(self):
 		os.chdir(self.temp_dir)

--- a/testers/libft/Alelievr.py
+++ b/testers/libft/Alelievr.py
@@ -51,12 +51,11 @@ class Alelievr():
 			f_init.writelines(lines)
 
 		if platform == "linux" or platform == "linux2":
-			linker_line = "\n\nso:\n\tgcc -nostartfiles -shared -o libft.so "
+			path_line = ""
 			if os.path.exists("../bin"):
-				linker_line += "bin/"
-			linker_line += "*.o\n"
+				path_line += "bin/"
 			with open(Path(self.temp_dir, "..", "__my_srcs", "Makefile"), 'a') as mf:
-				mf.writelines(linker_line)
+				mf.writelines("\n\nso:\n\tgcc -nostartfiles -shared -o libft.so " + path_line + "*.o\n")
 
 	def execute_tester(self):
 		os.chdir(self.temp_dir)


### PR DESCRIPTION
fixes an issue where  the test prepper on linux for libft-unit-test wouldn't look inside subfolders for objects files to compile the shared library
now it does, but only if the folder is named bin sadly, i couldn't find a way to make it work recursively
it is meant as a band-aid temporary fix