### PR TITLE
fix: Tester crashing with ft_calloc division by 0

### DIFF
--- a/testers/libft/Fsoares.py
+++ b/testers/libft/Fsoares.py
@@ -106,7 +106,11 @@ class Fsoares():
 			if lines[-1] == "":
 				lines = lines[:-1]
 			match = test_regex.match(lines[-1])
-			return (match.group(1), match.group(2), lines)
+
+			if match:
+				return (match.group(1), match.group(2), lines)
+			else:
+				return (func, "No match found", lines)
 
 		def parse_sanitizer(func, output: str):
 			if not output.startswith("================================="):


### PR DESCRIPTION
Before:
```
2023-04-29 12:42:17,803 [fsoares][INFO]: Floating point exception

2023-04-29 12:42:17,857 [base][ERROR]: 'NoneType' object has no attribute 'group'
Traceback (most recent call last):
  File "/home/ebouvier/francinette/testers/BaseTester.py", line 183, in test_using
    return (tester.name, tx.execute())
  File "/home/ebouvier/francinette/testers/libft/Fsoares.py", line 45, in execute
    result = self.execute_tests()
  File "/home/ebouvier/francinette/testers/libft/Fsoares.py", line 139, in execute_tests
    result = [execute_test(func) for func in self.to_execute]
  File "/home/ebouvier/francinette/testers/libft/Fsoares.py", line 139, in <listcomp>
    result = [execute_test(func) for func in self.to_execute]
  File "/home/ebouvier/francinette/testers/libft/Fsoares.py", line 137, in execute_test
    return parse_output(remove_ansi_colors(output), func)
  File "/home/ebouvier/francinette/testers/libft/Fsoares.py", line 109, in parse_output
    return (match.group(1), match.group(2), lines)
AttributeError: 'NoneType' object has no attribute 'group'
2023-04-29 12:42:17,858 [base][WARNING]: norminette errors: []
2023-04-29 12:42:17,858 [base][WARNING]: missing functions: []
2023-04-29 12:42:17,858 [base][WARNING]: errors in functions: [('fsoares', ['fsoares'])]
```
After:
```
ft_isalpha      : OK
ft_isdigit      : OK
ft_isalnum      : OK
ft_isascii      : OK
ft_isprint      : OK
ft_strlen       : OK
ft_memset       : OK
ft_bzero        : OK
ft_memcpy       : OK
ft_memmove      : OK
ft_strlcpy      : OK
ft_strlcat      : OK
ft_toupper      : OK
ft_tolower      : OK
ft_strchr       : OK
ft_strrchr      : OK
ft_strncmp      : OK
ft_memchr       : OK
ft_memcmp       : OK
ft_strnstr      : OK
ft_atoi         : OK
Floating point exception
ft_strdup       : OK
ft_substr       : OK
ft_strjoin      : OK
ft_strtrim      : OK
ft_split        : OK
ft_itoa         : OK
ft_strmapi      : OK
ft_striteri     : OK
ft_putchar_fd   : OK
ft_putstr_fd    : OK
ft_putendl_fd   : OK
ft_putnbr_fd    : OK
ft_lstnew       : OK
ft_lstadd_front : OK
ft_lstsize      : OK
ft_lstlast      : OK
ft_lstadd_back  : OK
ft_lstdelone    : OK
ft_lstclear     : OK
ft_lstiter      : OK
```
I didnt spend time checking how to properly test the division by 0.
