### PR TITLE
Fix: #67, Errors that were happening in fsoares's tests, at functions…

### DIFF
--- a/tests/libft/fsoares/test_putendl_fd.c
+++ b/tests/libft/fsoares/test_putendl_fd.c
@@ -11,7 +11,7 @@ int single_test_putendl(int test_number, char *str, int fd)
 
 int test_putendl_fd()
 {
-	int fd = open("fsoares", O_RDWR | O_CREAT);
+	int fd = open("fsoares", O_RDWR | O_CREAT, S_IRWXU);
 
 	int res = single_test_putendl(1, "", fd);
 	res = single_test_putendl(2, "abcdef", fd) && res;

--- a/tests/libft/fsoares/test_putnbr_fd.c
+++ b/tests/libft/fsoares/test_putnbr_fd.c
@@ -12,7 +12,7 @@ int single_test_putnbr(int test_number, int n, int fd)
 
 int test_putnbr_fd()
 {
-	int fd = open("fsoares", O_RDWR | O_CREAT);
+	int fd = open("fsoares", O_RDWR | O_CREAT, S_IRWXU);
 
 	int res = single_test_putnbr(1, 0, fd);
 	res = single_test_putnbr(2, 10000043, fd) && res;

--- a/tests/libft/fsoares/test_putstr_fd.c
+++ b/tests/libft/fsoares/test_putstr_fd.c
@@ -11,7 +11,7 @@ int single_test_putstr(int test_number, char *str, int fd)
 
 int test_putstr_fd()
 {
-	int fd = open("fsoares", O_RDWR | O_CREAT);
+	int fd = open("fsoares", O_RDWR | O_CREAT, S_IRWXU);
 
 	int res = single_test_putstr(1, "abcdef", fd);
 	res = single_test_putstr(2, "\n1234", fd) && res;


### PR DESCRIPTION
…: ft_putstr_fd, ft_putnbr_fd and ft_putendl_fd. The file to be opened did not have the correct permissions (write and read). It was added 'S_IRWXU' flag to 'open' of 'fd' variable

 Changes to be committed:
	modified:   tests/libft/fsoares/test_putendl_fd.c
	modified:   tests/libft/fsoares/test_putnbr_fd.c
	modified:   tests/libft/fsoares/test_putstr_fd.c