### PR TITLE
Enhanced atoi tester with extended range checks

### DIFF
--- a/tests/libft/fsoares/test_atoi.c
+++ b/tests/libft/fsoares/test_atoi.c
@@ -28,10 +28,14 @@ int test_atoi(void)
 	res = single_test_atoi(13, "1209") && res;
 	res = single_test_atoi(14, "12/3") && res;
 	res = single_test_atoi(15, "12;3") && res;
+	res = single_test_atoi(16, "92233720368547758070") && res;
+	res = single_test_atoi(17, "-92233720368547758080") && res;
+	res = single_test_atoi(18, "9223372036854775806") && res;
+	res = single_test_atoi(19, "-9223372036854775806") && res;
 	sprintf(buffer, "%i", INT_MAX);
-	res = single_test_atoi(16, buffer) && res;
+	res = single_test_atoi(20, buffer) && res;
 	sprintf(buffer, "%i", INT_MIN);
-	res = single_test_atoi(17, buffer) && res;
+	res = single_test_atoi(21, buffer) && res;
 
 	for (int i = 0; i <= 0xFF; i++) {
 		sprintf(buffer, "%c %i", i, i + 1);


### PR DESCRIPTION
I have made some modifications to the existing atoi tester to include additional checks for the range of the atoi function, ensuring it behaves correctly when the input exceeds the capacity of a long. The standard behavior of atoi is to return LONG_MAX (2^31-1) or LONG_MIN (-2^31) and set the errno to ERANGE when a number cannot be represented within the bounds of a long. This pull request enhances the tester to validate this specific behavior.

Changes Made:

Added test cases to cover scenarios where the input to atoi exceeds the capacity of a long.
Checked that atoi correctly returns depending on the sign of the input when the range is exceeded.
The purpose of these changes is to ensure that the tester comprehensively assesses the range-handling capabilities of the atoi implementation, helping to identify potential issues related to integer overflow and range checks.

I believe these enhancements will contribute to the robustness of the tester and aid in improving the overall quality of the tested atoi implementation.