### PR TITLE
fix: allow more assignment types in Makefile check

### DIFF
--- a/utils/Utils.py
+++ b/utils/Utils.py
@@ -85,7 +85,7 @@ def save_err_file(errors: str, temp_dir: Path):
 
 def is_makefile_project(current_path, project_name, project_class):
 	make_path = current_path / "Makefile"
-	name_matcher = re.compile(rf"^\s*NAME\s*:?=\s*{project_name}\s*$")
+	name_matcher = re.compile(rf"^\s*NAME\s*:{{0,3}}=\s*{project_name}\s*$")
 	logger.info(f"Makefile path: {make_path.resolve()}")
 	if not make_path.exists():
 		return False


### PR DESCRIPTION
Allows POSIX Simply Expanded Variable Assignments and Immediately Expanded Variable Assignments to be used for the `NAME` check in `Makefile` (https://www.gnu.org/software/make/manual/html_node/Flavors.html).